### PR TITLE
multi_site should enable cross site controllers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    multi_site (0.1)
+    multi_site (0.0.1)
       rails (>= 3.0)
 
 GEM
@@ -51,7 +51,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.20.1)
+    mime-types (1.21)
     multi_json (1.5.0)
     polyglot (0.3.3)
     rack (1.4.4)
@@ -101,7 +101,7 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.35)
+    tzinfo (0.3.37)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ from current site:
 ```ruby
 class UsersController < ApplicationController
   def  index
-  	#fetch all the users
-  	@all_users = User.all
-  	#fetch all the users from current site
-  	@site_users = User.on_site
+    #fetch all the users
+    @all_users = User.all
+    #fetch all the users from current site
+    @site_users = User.on_site
     #fetch all the users from current site with a certain age
     @site_users = User.on_site.where(:age => 15)
   end
@@ -88,9 +88,9 @@ MultiSite provides a helper method called `current_site`. It can be used on view
 context and give us the current site selected by the application.
 ```erb
 <% if current_site.present? %>
-	<p>Site Name: <%= current_site.name %></p>
+  <p>Site Name: <%= current_site.name %></p>
 <% else %>
-	<p> Please you need to <%= link_to "login", "/login" %> first.
+  <p> Please you need to <%= link_to "login", "/login" %> first.
 <% end %>
 ```
 #### Security
@@ -109,6 +109,25 @@ class UsersController < ApplicationController
     unless current_user.site == current_site
       raise "Access Denied"
     end
+  end
+end
+```
+
+#### Cross site controllers
+
+You'll surely need cross site operations. We can get you there providing a macro that allows site switching:
+
+```ruby
+class Admin::AdminController < ApplicationController
+  cross_site_controller
+
+  def show
+    @admin_site = current_site
+  end
+
+  def switch_site
+    self.current_site = Site.find(params[:site_id])
+    redirect_to admin_admin_url, notice: "Switched to: #{current_site.url}"
   end
 end
 ```
@@ -138,4 +157,3 @@ Thread.new {
 Copyright © 2013 [Runtime Revolution](http://www.runtime-revolution.com), released under the MIT license.
 
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/26b54a588b4f5698a9d33228e4eac957 "githalytics.com")](http://githalytics.com/runtimerevolution/multi_site)
-

--- a/lib/multi_site.rb
+++ b/lib/multi_site.rb
@@ -5,8 +5,10 @@ require "multi_site/version"
 require 'multi_site/rails/routes'
 require "multi_site/active_record.rb"
 require "multi_site/action_controller.rb"
+require "multi_site/supra/action_controller.rb"
 
 if defined?(ActiveRecord::Base)
   ActiveRecord::Base.send(:include, MultiSite::ActiveRecord)
   ActionController::Base.send(:include, MultiSite::ActionController)
+  ActionController::Base.extend(MultiSite::Supra::ActionController::Macro)
 end

--- a/lib/multi_site/action_controller.rb
+++ b/lib/multi_site/action_controller.rb
@@ -23,6 +23,5 @@ module MultiSite
         MultiSite.current_site = Site.find_by_url(params[:multi_site].to_s)
       end
     end
-
   end
 end

--- a/lib/multi_site/active_record.rb
+++ b/lib/multi_site/active_record.rb
@@ -1,5 +1,4 @@
 module MultiSite
-
   class << self
     def current_site=(site)
       Thread.current[:site_id] = site.try(:id)

--- a/lib/multi_site/supra/action_controller.rb
+++ b/lib/multi_site/supra/action_controller.rb
@@ -1,0 +1,77 @@
+module MultiSite
+  module Supra
+    mattr_reader :default_site
+    # accessor to declare the default site
+    def self.default_site=(site)
+      @@default_site = MultiSite::Supra.find_site(site)
+    end
+
+    class << self
+      # Set's the current site scope
+      def current_site=(site)
+        Thread.current[:scoped_site_id] = site.try(:id)
+      end
+
+      # Reads the current site
+      def current_site
+        Site.find(Thread.current[:scoped_site_id]) if Thread.current[:scoped_site_id]
+      end
+    end
+
+    # Provides controllers (tipically backoffice controllers) the ability to
+    # switch between site, thus scoping the data to the selected site.
+    #
+    # Set's the current site scope
+    #
+    # class Supra::AdminController < ApplicationController
+    #   def switch_site
+    #     self.current_site = Site.find(params[:site_id])
+    #     redirect_to :root
+    #   end
+    # end
+    #
+    # The default scoped site is declaration:
+    #
+    # MultiSite::Supra.default_site = Site.active.first
+    #
+    module ActionController
+      extend ActiveSupport::Concern
+
+      module Macro
+        # The class macro to declare a supra site controller
+        def cross_site_controller
+          include MultiSite::Supra::ActionController
+        end
+      end
+
+      included do
+        prepend_before_filter :set_current_site
+        helper_method :current_site
+      end
+
+      # controller accessor to set the current site
+      def current_site=(site)
+        MultiSite::Supra.current_site = MultiSite::Supra.find_site(site)
+      end
+
+      # the current site
+      def current_site
+        MultiSite::Supra.current_site
+      end
+
+      def set_current_site
+        MultiSite::Supra.current_site = Supra.current_site || MultiSite::Supra.default_site
+      end
+    end
+
+    private
+    def self.find_site(site)
+      case site
+      when String, Integer
+        Site.find_by_id(site)
+      else
+        site
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/supra_site_controller_spec.rb
+++ b/spec/controllers/admin/supra_site_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Admin::AdminController do
+  let!(:site) { FactoryGirl.create(:site) }
+  let!(:another_site) { FactoryGirl.create(:site, url: 'another_site') }
+
+  before(:each) { MultiSite::Supra.default_site = site }
+
+  it "is aware of a current site selection" do
+    get :show
+    assigns(:admin_site).should eq(site)
+  end
+
+  it "switches managed site" do
+    put :switch_site, site_id: another_site.id
+    get :show
+    assigns(:admin_site).should eq(another_site)
+  end
+end

--- a/spec/dummy/app/controllers/admin/admin_controller.rb
+++ b/spec/dummy/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,12 @@
+class Admin::AdminController < ApplicationController
+  cross_site_controller
+
+  def show
+    @admin_site = current_site
+  end
+
+  def switch_site
+    self.current_site = Site.find(params[:site_id])
+    redirect_to admin_admin_url, notice: "Switched to: #{current_site.url}"
+  end
+end

--- a/spec/dummy/app/models/site.rb
+++ b/spec/dummy/app/models/site.rb
@@ -1,4 +1,5 @@
 class Site < ActiveRecord::Base
+  has_many :users
 
   validates :url, :presence => true, :uniqueness => true
   attr_accessible :url

--- a/spec/dummy/app/views/admin/admin/show.erb
+++ b/spec/dummy/app/views/admin/admin/show.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @users.each do |user| %>
+    <li><%= user.name %></li>
+  <% end %>
+</ul>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,4 +4,10 @@ Dummy::Application.routes.draw do
   multi_site_scope do
     resources :users
   end
+
+  namespace :admin do
+    resource :admin, controller: 'admin' do
+      put :switch_site
+    end
+  end
 end

--- a/spec/multi_site_spec.rb
+++ b/spec/multi_site_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
 
 describe "MultiSite" do
-
   it "should be true if the number of users shown in the site scope is the same doing a where query" do
-      site_1 = FactoryGirl.create(:site)
-      site_2 = FactoryGirl.create(:site)
-      site_3 = FactoryGirl.create(:site)
+    site_1 = FactoryGirl.create(:site)
+    site_2 = FactoryGirl.create(:site)
+    site_3 = FactoryGirl.create(:site)
 
-      20.times { FactoryGirl.create(:user, :site => site_1) }
-      10.times { FactoryGirl.create(:user, :site => site_2) }
+    20.times { FactoryGirl.create(:user, :site => site_1) }
+    10.times { FactoryGirl.create(:user, :site => site_2) }
 
     MultiSite.current_site = site_1
     User.on_site.count.should == User.where(:site_id => site_1.id).count
@@ -23,9 +22,8 @@ describe "MultiSite" do
   it "should return true if users is scoped by site" do
     answer = User.is_scoped_by_site?
     answer.should == true
-    
+
     answer = Site.is_scoped_by_site?
     answer.should == false
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,10 @@ Site.delete_all
 FactoryGirl.find_definitions
 
 RSpec.configure do |config|
-
   require 'rspec/expectations'
-  config.include RSpec::Matchers
 
+  config.include RSpec::Matchers
+  config.use_transactional_examples = true
   config.expect_with :rspec do |c|
     c.syntax = [:should]
   end


### PR DESCRIPTION
This pull request adds infrastructure for cross site control. 

Cross site control is a recurrent need, typically for back-office operations, multi_site should provide some level of abstraction.

This pull request provides the macro `cross_site_controller` to ease the declaration of supra site controllers.

Specs and a README update are included. 
Please review.

Cheers
